### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project provides a set of Model Context Protocol (MCP) tools that enable AI agents to interact with your local Logseq instance.
 
+<a href="https://glama.ai/mcp/servers/@apw124/logseq-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@apw124/logseq-mcp/badge" alt="Logseq Tools MCP server" />
+</a>
+
 ## Installation
 
 1. Ensure you have Python 3.11+ installed


### PR DESCRIPTION
This PR adds a badge for the [Logseq MCP Tools](https://glama.ai/mcp/servers/@apw124/logseq-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@apw124/logseq-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@apw124/logseq-mcp/badge" alt="Logseq Tools MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.